### PR TITLE
Public methods

### DIFF
--- a/bstream.go
+++ b/bstream.go
@@ -172,3 +172,9 @@ func (b *BStream) ReadBits(count int) (uint64, error) {
 
 	return retValue, nil
 }
+
+// Bytes returns the bytes in the stream - taken from
+// https://github.com/dgryski/go-tsz/bstream.go
+func (b *BStream) Bytes() []byte {
+	return b.stream
+}

--- a/bstream.go
+++ b/bstream.go
@@ -39,8 +39,8 @@ func (b *BStream) WriteBit(input bit) {
 	b.remainCount--
 }
 
-//WriteByte :
-func (b *BStream) WriteByte(data byte) {
+//WriteOneByte :
+func (b *BStream) WriteOneByte(data byte) {
 	if b.remainCount == 0 {
 		b.stream = append(b.stream, 0)
 		b.remainCount = 8
@@ -61,7 +61,7 @@ func (b *BStream) WriteBits(data uint64, count int) {
 	//handle write byte if count over 8
 	for count >= 8 {
 		byt := byte(data >> (64 - 8))
-		b.WriteByte(byt)
+		b.WriteOneByte(byt)
 
 		data <<= 8
 		count -= 8

--- a/bstream.go
+++ b/bstream.go
@@ -26,7 +26,7 @@ func NewBStreamWriter(nByte uint8) *BStream {
 }
 
 //WriteBit :
-func (b *BStream) writeBit(input bit) {
+func (b *BStream) WriteBit(input bit) {
 	if b.remainCount == 0 {
 		b.stream = append(b.stream, 0)
 		b.remainCount = 8
@@ -40,7 +40,7 @@ func (b *BStream) writeBit(input bit) {
 }
 
 //WriteByte :
-func (b *BStream) writeByte(data byte) {
+func (b *BStream) WriteByte(data byte) {
 	if b.remainCount == 0 {
 		b.stream = append(b.stream, 0)
 		b.remainCount = 8
@@ -61,7 +61,7 @@ func (b *BStream) WriteBits(data uint64, count int) {
 	//handle write byte if count over 8
 	for count >= 8 {
 		byt := byte(data >> (64 - 8))
-		b.writeByte(byt)
+		b.WriteByte(byt)
 
 		data <<= 8
 		count -= 8
@@ -70,14 +70,14 @@ func (b *BStream) WriteBits(data uint64, count int) {
 	//handle write bit
 	for count > 0 {
 		bi := data >> (64 - 1)
-		b.writeBit(bi == 1)
+		b.WriteBit(bi == 1)
 
 		data <<= 1
 		count--
 	}
 }
 
-func (b *BStream) readBit() (bit, error) {
+func (b *BStream) ReadBit() (bit, error) {
 	//empty return io.EOF
 	if len(b.stream) == 0 {
 		return zero, io.EOF
@@ -102,7 +102,7 @@ func (b *BStream) readBit() (bit, error) {
 	return retBit != 0, nil
 }
 
-func (b *BStream) readByte() (byte, error) {
+func (b *BStream) ReadByte() (byte, error) {
 	//empty return io.EOF
 	if len(b.stream) == 0 {
 		return 0, io.EOF
@@ -149,7 +149,7 @@ func (b *BStream) ReadBits(count int) (uint64, error) {
 	//handle byte reading
 	for count >= 8 {
 		retValue <<= 8
-		byt, err := b.readByte()
+		byt, err := b.ReadByte()
 		if err != nil {
 			return 0, err
 		}
@@ -159,7 +159,7 @@ func (b *BStream) ReadBits(count int) (uint64, error) {
 
 	for count > 0 {
 		retValue <<= 1
-		bi, err := b.readBit()
+		bi, err := b.ReadBit()
 		if err != nil {
 			return 0, err
 		}

--- a/bstream_test.go
+++ b/bstream_test.go
@@ -4,16 +4,16 @@ import "testing"
 
 func TestWriteBit(t *testing.T) {
 	b := NewBStreamWriter(5)
-	b.writeBit(one)
+	b.WriteBit(one)
 	if b.stream[0] != 128 {
 		t.Error("first bit error")
 	}
-	b.writeBit(one)
+	b.WriteBit(one)
 	if b.stream[0] != 192 {
 		t.Error("second bit error")
 	}
 
-	b.writeBit(one)
+	b.WriteBit(one)
 	if b.stream[0] != 224 {
 		t.Error("third bit error")
 	}
@@ -21,16 +21,16 @@ func TestWriteBit(t *testing.T) {
 
 func TestWriteByte(t *testing.T) {
 	b := NewBStreamWriter(5)
-	b.writeByte(0xff)
+	b.WriteByte(0xff)
 	if b.stream[0] != 255 {
 		t.Error("first byte error")
 	}
-	b.writeByte(0xa0)
+	b.WriteByte(0xa0)
 	if b.stream[1] != 160 {
 		t.Error("second byte error")
 	}
 
-	b.writeByte(0x00)
+	b.WriteByte(0x00)
 	if b.stream[2] != 0 {
 		t.Error("third byte error")
 	}
@@ -38,8 +38,8 @@ func TestWriteByte(t *testing.T) {
 
 func TestWriteCombo(t *testing.T) {
 	b := NewBStreamWriter(5)
-	b.writeBit(one)
-	b.writeByte(0xaa)
+	b.WriteBit(one)
+	b.WriteByte(0xaa)
 
 	c := NewBStreamWriter(5)
 	c.WriteBits(0xaa, 8)
@@ -62,13 +62,13 @@ func TestReadBit(t *testing.T) {
 	b := NewBStreamWriter(5)
 	b.WriteBits(0xa0, 8)
 
-	bit, err := b.readBit()
+	bit, err := b.ReadBit()
 
 	if err != nil || bit == zero {
 		t.Error("Read first bit error")
 	}
 
-	bit, err = b.readBit()
+	bit, err = b.ReadBit()
 
 	if err != nil || bit == one {
 		t.Error("Read second bit error")
@@ -79,13 +79,13 @@ func TestReadByte(t *testing.T) {
 	b := NewBStreamWriter(5)
 	b.WriteBits(0xa5a5, 16)
 
-	bit, err := b.readBit()
+	bit, err := b.ReadBit()
 
 	if err != nil || bit == zero {
 		t.Error("Read first bit error")
 	}
 
-	byt, err := b.readByte()
+	byt, err := b.ReadByte()
 	if byt != 75 {
 		t.Error("Read byte error")
 	}

--- a/bstream_test.go
+++ b/bstream_test.go
@@ -19,18 +19,18 @@ func TestWriteBit(t *testing.T) {
 	}
 }
 
-func TestWriteByte(t *testing.T) {
+func TestWriteOneByte(t *testing.T) {
 	b := NewBStreamWriter(5)
-	b.WriteByte(0xff)
+	b.WriteOneByte(0xff)
 	if b.stream[0] != 255 {
 		t.Error("first byte error")
 	}
-	b.WriteByte(0xa0)
+	b.WriteOneByte(0xa0)
 	if b.stream[1] != 160 {
 		t.Error("second byte error")
 	}
 
-	b.WriteByte(0x00)
+	b.WriteOneByte(0x00)
 	if b.stream[2] != 0 {
 		t.Error("third byte error")
 	}
@@ -39,7 +39,7 @@ func TestWriteByte(t *testing.T) {
 func TestWriteCombo(t *testing.T) {
 	b := NewBStreamWriter(5)
 	b.WriteBit(one)
-	b.WriteByte(0xaa)
+	b.WriteOneByte(0xaa)
 
 	c := NewBStreamWriter(5)
 	c.WriteBits(0xaa, 8)


### PR DESCRIPTION
Make all methods public and add a Bytes() function to be able to extract the entire bitstream. This allows full use of the library in other packages.