### PR TITLE
Making the library safer to use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 BStream: A Bit Stream helper in Golang 
 ==================
 
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/kkdai/bloomfilter/master/LICENSE)  [![GoDoc](https://godoc.org/github.com/kkdai/bstream?status.svg)](https://godoc.org/github.com/kkdai/bstream)  [![Build Status](https://travis-ci.org/kkdai/bstream.svg?branch=master)](https://travis-ci.org/kkdai/bstream)[![](https://goreportcard.com/badge/github.com/kkdai/bstream)](https://goreportcard.com/report/github.com/kkdai/bstream)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/kkdai/bloomfilter/master/LICENSE)  [![GoDoc](https://godoc.org/github.com/kkdai/bstream?status.svg)](https://godoc.org/github.com/kkdai/bstream)  [![Build Status](https://travis-ci.org/kkdai/bstream.svg?branch=master)](https://travis-ci.org/kkdai/bstream)[![](https://goreportcard.com/badge/github.com/kkdai/bstream)
+](https://goreportcard.com/report/github.com/kkdai/bstream)
 
 
 
@@ -28,6 +29,12 @@ Usage
 	}
 ```
 
+Notes
+---------------
+
+- BStream is *not* thread safe. When you need to use it from different goroutines, you need to manage locking yourself.
+- You can use the same `*BStream` object for reading & writing. However note that currently it is possible to read zero-value data if you read more bits than what has been written.
+- BStream will *not* modify the data provided to `NewBStreamReader`. You can reuse the same `*BStream` object for writing and it will allocate a new underlying buffer.
 
 Inspired
 ---------------

--- a/bstream_test.go
+++ b/bstream_test.go
@@ -1,6 +1,9 @@
 package bstream
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestWriteBit(t *testing.T) {
 	b := NewBStreamWriter(5)
@@ -29,10 +32,12 @@ func TestWriteOneByte(t *testing.T) {
 	if b.stream[1] != 160 {
 		t.Error("second byte error")
 	}
-
 	b.WriteOneByte(0x00)
 	if b.stream[2] != 0 {
 		t.Error("third byte error")
+	}
+	if l := len(b.Bytes()); l != 3 {
+		t.Errorf("Expected %v bytes but got %v", 3, l)
 	}
 }
 
@@ -40,6 +45,9 @@ func TestWriteCombo(t *testing.T) {
 	b := NewBStreamWriter(5)
 	b.WriteBit(one)
 	b.WriteOneByte(0xaa)
+	if b.stream[0] != 0xD5 || b.stream[1] != 0x00 {
+		t.Error("write bits wrong")
+	}
 
 	c := NewBStreamWriter(5)
 	c.WriteBits(0xaa, 8)
@@ -53,7 +61,7 @@ func TestWriteCombo(t *testing.T) {
 	}
 
 	c.WriteBits(0x0a0a, 16)
-	if c.stream[4] != 0x0 {
+	if len(c.stream) > 4 {
 		t.Error("write bit error when too much")
 	}
 }
@@ -94,15 +102,68 @@ func TestReadByte(t *testing.T) {
 func TestWriteBits(t *testing.T) {
 	b := NewBStreamWriter(24)
 	b.WriteBits(0xa5a5, 16)
+	b.WriteBits(0x07, 3)
 
 	ret, err := b.ReadBits(12)
 	if err != nil || ret != 2650 {
 		t.Error("ReadBits error")
 	}
-
 	ret, err = b.ReadBits(4)
 	if err != nil || ret != 5 {
 		t.Error("ReadBits second error")
+	}
+	ret, err = b.ReadBits(3)
+	if err != nil || ret != 7 {
+		t.Error("ReadBits third error")
+	}
+}
+
+func TestDualMode(t *testing.T) {
+	b := NewBStreamWriter(1)
+
+	b.WriteBit(one)
+	b.WriteBit(zero)
+	b.WriteBit(one)
+
+	if bit, err := b.ReadBit(); err != nil || bit == zero {
+		t.Error("Read first bit error")
+	}
+
+	b.WriteBit(one)
+
+	if bit, err := b.ReadBit(); err != nil || bit == one {
+		t.Error("Read second bit error")
+	}
+	if bit, err := b.ReadBit(); err != nil || bit == zero {
+		t.Error("Read third bit error")
+	}
+
+	b.WriteBit(one)
+
+	if bit, err := b.ReadBit(); err != nil || bit == zero {
+		t.Error("Read fourth bit error")
+	}
+	if bit, err := b.ReadBit(); err != nil || bit == zero {
+		t.Error("Read fifth bit error")
+	}
+
+	if len(b.stream) != 1 || b.stream[0] != 0xB8 {
+		t.Error("Wrong stream result")
+	}
+}
+
+func TestPreserveInput(t *testing.T) {
+	var data = []byte{0xAA, 0xAA}
+	input := make([]byte, len(data))
+	copy(input, data)
+
+	bs := NewBStreamReader(input)
+
+	bs.ReadBits(1)
+	bs.ReadByte()
+
+	if !reflect.DeepEqual(data, input) {
+		t.Error("Expected input to remain same after reading")
 	}
 }
 


### PR DESCRIPTION
Hello!

This library is useful but I ran into a few issues which I then proceeded to solve and include in this PR.

The main two changes are:

* No longer modifying the underlying data provided to `NewBStreamReader(data []byte)`. It caused all sorts of weird unexpected behavior because it's not usually the case in idiomatic Go that readers modify data.

* Now supporting reading & writing on the same `*BStream` object. Previously a single `remainCount` int was used to track both operations, which meant that data corruption would happen.